### PR TITLE
fix: sane exit from a go routine

### DIFF
--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -483,6 +483,10 @@ func (t *Ticker) readMessage(wg *sync.WaitGroup) {
 
 // Close tries to close the connection gracefully. If the server doesn't close it
 func (t *Ticker) Close() error {
+	// TODO handle ontriggerClose
+	// maybe reset state (after Zerodha team finalises the change)
+	// https://github.com/zerodha/gokiteconnect/pull/28
+
 	err := t.Conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
 	if !err {

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -502,7 +502,9 @@ func (t *Ticker) Close() error {
 // Graceful Manual Close
 // which doesn't trigger reconnect
 func (t *Ticker) ManualClose() {
-	t.Conn.Close()
+	if t.Conn != nil {
+		t.Conn.Close()
+	}
 	t.manuallyClosed = true
 }
 

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -83,7 +83,7 @@ type Ticker struct {
 	reconnectMaxDelay   time.Duration
 	connectTimeout      time.Duration
 
-	manualClosed bool
+	manuallyClosed bool
 
 	reconnectAttempt int
 
@@ -285,7 +285,7 @@ func (t *Ticker) Serve() {
 	for {
 
 		// If closed by user
-		if t.manualClosed {
+		if t.manuallyClosed {
 			return
 		}
 
@@ -438,7 +438,7 @@ func (t *Ticker) checkConnection(wg *sync.WaitGroup) {
 		time.Sleep(connectionCheckInterval)
 
 		// checkConnection runs in a separate goroutine. Safer to exit ASAP
-		if t.manualClosed {
+		if t.manuallyClosed {
 			wg.Done()
 			return
 		}
@@ -503,7 +503,7 @@ func (t *Ticker) Close() error {
 // which doesn't trigger reconnect
 func (t *Ticker) ManualClose() {
 	t.Conn.Close()
-	t.manualClosed = true
+	t.manuallyClosed = true
 }
 
 // Subscribe subscribes tick for the given list of tokens.

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -487,14 +487,14 @@ func (t *Ticker) Close() error {
 	// maybe reset state (after Zerodha team finalises the change)
 	// https://github.com/zerodha/gokiteconnect/pull/28
 
-	err := t.Conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-
-	if !err {
-		t.Conn = nil
-		t.isClosed = true
+	if err := t.Conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+		return err
 	}
 
-	return err
+	t.Conn = nil
+	t.isClosed = true
+
+	return nil
 }
 
 // Subscribe subscribes tick for the given list of tokens.


### PR DESCRIPTION
Hi,

Issue faced:- Getting the go routine which runs `ticker.Serve()` to exit. Since it runs forever normal signalling mechanisms do not work (using a channel or a context).

Say I initiate `ticker.Serve()` using a go routine, how do I stop it now?
If I execute `ticker.Close()` the go routine would just re-connect.

My changes are an attempt to address the above :+1: 

------------

- Why didn't I reset state on close? (reconnectAttempt etc)   
   I felt if the client wants to reconnect, it's standard practice to create a new ticker anyways. If you think otherwise, I can make the required change.

- Once these changes are approved, we can probably handle the onClose as well. `Close()` doesn't trigger `onClose` at the moment.

- Use locks if required. `Close()` will be called from another thread.