### PR TITLE
Add OI support to Historical Data

### DIFF
--- a/market.go
+++ b/market.go
@@ -77,6 +77,7 @@ type HistoricalData struct {
 	Low    float64 `json:"Low"`
 	Close  float64 `json:"close"`
 	Volume int     `json:"volume"`
+	Oi     int     `json:"oi"`
 }
 
 type historicalDataReceived struct {
@@ -87,6 +88,7 @@ type historicalDataParams struct {
 	FromDate        string `url:"from"`
 	ToDate          string `url:"to"`
 	Continuous      int    `url:"continuous"`
+	Oi              int    `url:"oi"`
 	InstrumentToken int    `url:"instrument_token"`
 	Interval        string `url:"interval"`
 }
@@ -208,6 +210,7 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 			low    float64
 			close  float64
 			volume int
+			oi     int
 			ok     bool
 		)
 
@@ -238,6 +241,15 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 		}
 
 		volume = int(v)
+		// Did we get OI?
+		if len(i) > 6 {
+			// Assert oi
+			oit, ok := i[6].(float64)
+			if !ok {
+				return data, NewError(GeneralError, fmt.Sprintf("Error decoding response `oi`: %v", i[6]), nil)
+			}
+			oi = int(oit)
+		}
 
 		// Parse string to date
 		d, err := time.Parse("2006-01-02T15:04:05-0700", ds)
@@ -252,6 +264,7 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 			Low:    low,
 			Close:  close,
 			Volume: volume,
+			Oi:     oi,
 		})
 	}
 
@@ -259,7 +272,7 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 }
 
 // GetHistoricalData gets list of historical data.
-func (c *Client) GetHistoricalData(instrumentToken int, interval string, fromDate time.Time, toDate time.Time, continuous bool) ([]HistoricalData, error) {
+func (c *Client) GetHistoricalData(instrumentToken int, interval string, fromDate time.Time, toDate time.Time, continuous bool, Oi bool) ([]HistoricalData, error) {
 	var (
 		err       error
 		data      []HistoricalData
@@ -272,9 +285,14 @@ func (c *Client) GetHistoricalData(instrumentToken int, interval string, fromDat
 	inpParams.FromDate = fromDate.Format("2006-01-02 15:04:05")
 	inpParams.ToDate = toDate.Format("2006-01-02 15:04:05")
 	inpParams.Continuous = 0
+	inpParams.Oi = 0
 
 	if continuous {
 		inpParams.Continuous = 1
+	}
+
+	if Oi {
+		inpParams.Oi = 1
 	}
 
 	if params, err = query.Values(inpParams); err != nil {

--- a/market.go
+++ b/market.go
@@ -77,7 +77,7 @@ type HistoricalData struct {
 	Low    float64 `json:"Low"`
 	Close  float64 `json:"close"`
 	Volume int     `json:"volume"`
-	Oi     int     `json:"oi"`
+	OI     int     `json:"oi"`
 }
 
 type historicalDataReceived struct {
@@ -88,7 +88,7 @@ type historicalDataParams struct {
 	FromDate        string `url:"from"`
 	ToDate          string `url:"to"`
 	Continuous      int    `url:"continuous"`
-	Oi              int    `url:"oi"`
+	OI              int    `url:"oi"`
 	InstrumentToken int    `url:"instrument_token"`
 	Interval        string `url:"interval"`
 }
@@ -210,7 +210,7 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 			low    float64
 			close  float64
 			volume int
-			oi     int
+			OI     int
 			ok     bool
 		)
 
@@ -243,12 +243,12 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 		volume = int(v)
 		// Did we get OI?
 		if len(i) > 6 {
-			// Assert oi
-			oit, ok := i[6].(float64)
+			// Assert OI
+			OIT, ok := i[6].(float64)
 			if !ok {
 				return data, NewError(GeneralError, fmt.Sprintf("Error decoding response `oi`: %v", i[6]), nil)
 			}
-			oi = int(oit)
+			OI = int(OIT)
 		}
 
 		// Parse string to date
@@ -264,7 +264,7 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 			Low:    low,
 			Close:  close,
 			Volume: volume,
-			Oi:     oi,
+			OI:     OI,
 		})
 	}
 
@@ -272,7 +272,7 @@ func (c *Client) formatHistoricalData(inp historicalDataReceived) ([]HistoricalD
 }
 
 // GetHistoricalData gets list of historical data.
-func (c *Client) GetHistoricalData(instrumentToken int, interval string, fromDate time.Time, toDate time.Time, continuous bool, Oi bool) ([]HistoricalData, error) {
+func (c *Client) GetHistoricalData(instrumentToken int, interval string, fromDate time.Time, toDate time.Time, continuous bool, OI bool) ([]HistoricalData, error) {
 	var (
 		err       error
 		data      []HistoricalData
@@ -285,14 +285,14 @@ func (c *Client) GetHistoricalData(instrumentToken int, interval string, fromDat
 	inpParams.FromDate = fromDate.Format("2006-01-02 15:04:05")
 	inpParams.ToDate = toDate.Format("2006-01-02 15:04:05")
 	inpParams.Continuous = 0
-	inpParams.Oi = 0
+	inpParams.OI = 0
 
 	if continuous {
 		inpParams.Continuous = 1
 	}
 
-	if Oi {
-		inpParams.Oi = 1
+	if OI {
+		inpParams.OI = 1
 	}
 
 	if params, err = query.Values(inpParams); err != nil {

--- a/market_test.go
+++ b/market_test.go
@@ -39,7 +39,7 @@ func (ts *TestSuite) TestGetLTP(t *testing.T) {
 
 func (ts *TestSuite) TestGetHistoricalData(t *testing.T) {
 	t.Parallel()
-	marketHistorical, err := ts.KiteConnect.GetHistoricalData(123, "myinterval", time.Unix(0, 0), time.Unix(1, 0), true)
+	marketHistorical, err := ts.KiteConnect.GetHistoricalData(123, "myinterval", time.Unix(0, 0), time.Unix(1, 0), true, false)
 	if err != nil {
 		t.Errorf("Error while fetching MF orders. %v", err)
 	}


### PR DESCRIPTION
I have added support of OI historical data but unfortunately it required an extra parameter, if we had used struct, it could have been avoided but it is what it is.

https://kite.trade/docs/connect/v3/historical/#oi-data

Now sample output:


```

    ...    {
        Date: kiteconnect.Time{
            Time: time.Time{
                wall: 0x0,
                ext:  63745946280,
                loc:  &time.Location{
                    name: "Local",
                    zone: {
                        {name:"LMT", offset:21208, isDST:false},
                        {name:"HMT", offset:21200, isDST:false},
                        {name:"MMT", offset:19270, isDST:false},
                        {name:"IST", offset:19800, isDST:false},
                        {name:"+0630", offset:23400, isDST:true},
                    },
                    tx: {
                        {when:-3645237208, index:0x1, isstd:false, isutc:false},
                        {when:-3155694800, index:0x2, isstd:false, isutc:false},
                        {when:-2019705670, index:0x3, isstd:false, isutc:false},
                        {when:-891581400, index:0x4, isstd:false, isutc:false},
                        {when:-872058600, index:0x3, isstd:false, isutc:false},
                        {when:-862637400, index:0x4, isstd:false, isutc:false},
                        {when:-764145000, index:0x3, isstd:false, isutc:false},
                    },
                    extend:     "IST-5:30",
                    cacheStart: 9223372036854775807,
                    cacheEnd:   9223372036854775807,
                    cacheZone:  &time.zone{(CYCLIC REFERENCE)},
                },
            },
        },
        Open:   14504,
        High:   14504,
        Low:    14500.4,
        Close:  14500.4,
        Volume: 375,
        Oi:     131925,
    },
    {
        Date: kiteconnect.Time{
            Time: time.Time{
                wall: 0x0,
                ext:  63745946340,
                loc:  &time.Location{
                    name: "Local",
                    zone: {
                        {name:"LMT", offset:21208, isDST:false},
                        {name:"HMT", offset:21200, isDST:false},
                        {name:"MMT", offset:19270, isDST:false},
                        {name:"IST", offset:19800, isDST:false},
                        {name:"+0630", offset:23400, isDST:true},
                    },
                    tx: {
                        {when:-3645237208, index:0x1, isstd:false, isutc:false},
                        {when:-3155694800, index:0x2, isstd:false, isutc:false},
                        {when:-2019705670, index:0x3, isstd:false, isutc:false},
                        {when:-891581400, index:0x4, isstd:false, isutc:false},
                        {when:-872058600, index:0x3, isstd:false, isutc:false},
                        {when:-862637400, index:0x4, isstd:false, isutc:false},
                        {when:-764145000, index:0x3, isstd:false, isutc:false},
                    },
                    extend:     "IST-5:30",
                    cacheStart: 9223372036854775807,
                    cacheEnd:   9223372036854775807,
                    cacheZone:  &time.zone{(CYCLIC REFERENCE)},
                },
            },
        },
        Open:   14500.4,
        High:   14500.4,
        Low:    14500.4,
        Close:  14500.4,
        Volume: 300,
        Oi:     131925,
    },
...
...

```