### PR TITLE
Refactor custom time

### DIFF
--- a/models/time.go
+++ b/models/time.go
@@ -6,32 +6,49 @@ import (
 )
 
 // Time is custom time format used in all responses
-type Time struct {
-	time.Time
-}
+type Time time.Time
 
 // List of known time formats
-var ctLayouts = []string{"2006-01-02", "2006-01-02 15:04:05", "2006-01-02T15:04:05-0700"}
+var (
+	ctLayouts      = []string{"2006-01-02", "2006-01-02 15:04:05"}
+	ctZonedLayouts = []string{"2006-01-02T15:04:05-0700"}
+)
 
 // UnmarshalJSON parses JSON time string with custom time formats
 func (t *Time) UnmarshalJSON(b []byte) (err error) {
 	var pTime time.Time
-	s := strings.TrimSpace(strings.Trim(string(b), "\""))
 
+	s := strings.TrimSpace(strings.Trim(string(b), "\""))
 	if s == "" || s == "null" {
-		t.Time = pTime
+		*t = Time(pTime)
 		return nil
 	}
 
-	// Iterate through known layouts and parse time
+	// Load IST location.
+	loc, err := time.LoadLocation("IST")
+	if err != nil {
+		return err
+	}
+
+	// Iterate through zonless layouts and assign zone as IST.
 	for _, l := range ctLayouts {
-		pTime, err = time.Parse(l, s)
+		pTime, err = time.ParseInLocation(l, s, loc)
 		if err == nil && !pTime.IsZero() {
 			break
 		}
 	}
 
-	t.Time = pTime
+	// If pattern not found then iterate and parse layouts with zone.
+	if pTime.IsZero() {
+		for _, l := range ctZonedLayouts {
+			pTime, err = time.Parse(l, s)
+			if err == nil && !pTime.IsZero() {
+				break
+			}
+		}
+	}
+
+	*t = Time(pTime)
 	return nil
 }
 


### PR DESCRIPTION
Refactored `models.Time` to parse different types of layouts and assign IST timezone layouts without timezone info. 