### PR TITLE
fix: dont change http status code in readEnvelope

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -35,36 +35,44 @@ func (e Error) Error() string {
 // NewError creates and returns a new instace of Error
 // with custom error metadata.
 func NewError(etype string, message string, data interface{}) error {
-	err := Error{}
-	err.Message = message
-	err.ErrorType = etype
-	err.Data = data
+	var (
+		code = http.StatusInternalServerError
+	)
 
 	switch etype {
 	case GeneralError:
-		err.Code = http.StatusInternalServerError
+		code = http.StatusInternalServerError
 	case TokenError:
-		err.Code = http.StatusForbidden
+		code = http.StatusForbidden
 	case PermissionError:
-		err.Code = http.StatusForbidden
+		code = http.StatusForbidden
 	case UserError:
-		err.Code = http.StatusForbidden
+		code = http.StatusForbidden
 	case TwoFAError:
-		err.Code = http.StatusForbidden
+		code = http.StatusForbidden
 	case OrderError:
-		err.Code = http.StatusBadRequest
+		code = http.StatusBadRequest
 	case InputError:
-		err.Code = http.StatusBadRequest
+		code = http.StatusBadRequest
 	case DataError:
-		err.Code = http.StatusGatewayTimeout
+		code = http.StatusGatewayTimeout
 	case NetworkError:
-		err.Code = http.StatusServiceUnavailable
+		code = http.StatusServiceUnavailable
 	default:
-		err.Code = http.StatusInternalServerError
-		err.ErrorType = GeneralError
+		code = http.StatusInternalServerError
+		etype = GeneralError
 	}
 
-	return err
+	return newError(etype, message, code, data)
+}
+
+func newError(etype, message string, code int, data interface{}) Error {
+	return Error{
+		Message:   message,
+		ErrorType: etype,
+		Data:      data,
+		Code:      code,
+	}
 }
 
 // GetErrorName returns an error name given an HTTP code.

--- a/http.go
+++ b/http.go
@@ -162,7 +162,7 @@ func readEnvelope(resp HTTPResponse, obj interface{}) error {
 			return NewError(DataError, "Error parsing response.", nil)
 		}
 
-		return NewError(e.ErrorType, e.Message, e.Data)
+		return newError(e.ErrorType, e.Message, resp.Response.StatusCode, e.Data)
 	}
 
 	// We now unmarshal the body.


### PR DESCRIPTION
Refactor and create a new internal `newError` that sets the incoming http status code instead of using the helper externally exposed utility `NewError` method.

Then users can do something along the lines of the following inside their apps

```go
o, err := kc.PlaceMFOrder()
if err != nil {
  kcErr, ok := err.(kc.Error)
  if ok {
    if err.StatusCode == 428 {
      initHoldingAuth()
    }
  }  
}
```

Closes #54 

cc @vividvilla @vishnus 