### PR TITLE
fix: log only if non Error errors in readEnvelope

### DIFF
--- a/http.go
+++ b/http.go
@@ -148,7 +148,9 @@ func (h *httpClient) DoEnvelope(method, url string, params url.Values, headers h
 
 	err = readEnvelope(resp, obj)
 	if err != nil {
-		h.hLog.Printf("Error parsing JSON response: %v", err)
+		if _, ok := err.(Error); !ok {
+			h.hLog.Printf("Error parsing JSON response: %v", err)
+		}
 	}
 
 	return err


### PR DESCRIPTION
@vishnus reported extra logs for recently added #58 

`base.HTTP: 2021/07/12 16:39:33 http.go:151: Error parsing JSON response: 34.463 quantity needs authorisation at the depository.`

We should only log if its a non-`kiteconnect.Error`