### PR TITLE
fix: incorrect custom time json unmarshalling

### DIFF
--- a/models/time.go
+++ b/models/time.go
@@ -14,7 +14,7 @@ type Time struct {
 // List of known time formats
 var (
 	ctLayouts      = []string{"2006-01-02", "2006-01-02 15:04:05"}
-	ctZonedLayouts = []string{"2006-01-02T15:04:05-0700"}
+	ctZonedLayouts = []string{"2006-01-02T15:04:05-0700", time.RFC3339}
 )
 
 // UnmarshalJSON parses JSON time string with custom time formats

--- a/orders_test.go
+++ b/orders_test.go
@@ -1,6 +1,7 @@
 package kiteconnect
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -140,5 +141,30 @@ func (ts *TestSuite) TestExitOrder(t *testing.T) {
 	}
 	if orderResponse.OrderID == "" {
 		t.Errorf("No order id returned. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestIssue64(t *testing.T) {
+	t.Parallel()
+	orders, err := ts.KiteConnect.GetOrders()
+	if err != nil {
+		t.Errorf("Error while fetching orders. %v", err)
+	}
+
+	// Check if marshal followed by unmarshall correctly parses timestamps
+	ord := orders[0]
+	js, err := json.Marshal(ord)
+	if err != nil {
+		t.Errorf("Error while marshalling order. %v", err)
+	}
+
+	var outOrd Order
+	err = json.Unmarshal(js, &outOrd)
+	if err != nil {
+		t.Errorf("Error while unmarshalling order. %v", err)
+	}
+
+	if !ord.ExchangeTimestamp.Equal(outOrd.ExchangeTimestamp.Time) {
+		t.Errorf("Incorrect timestamp parsing.\nwant:\t%v\ngot:\t%v", ord.ExchangeTimestamp, outOrd.ExchangeTimestamp)
 	}
 }


### PR DESCRIPTION
This commit adds support for unmarshalling json timestamps using
RFC3339 which is the default time.Time json Marshaller.

Closes #64