### PR TITLE
Fixed json tag for low in Historical Data

### DIFF
--- a/market.go
+++ b/market.go
@@ -54,7 +54,7 @@ type HistoricalData struct {
 	Date   models.Time `json:"date"`
 	Open   float64     `json:"open"`
 	High   float64     `json:"high"`
-	Low    float64     `json:"Low"`
+	Low    float64     `json:"low"`
 	Close  float64     `json:"close"`
 	Volume int         `json:"volume"`
 	OI     int         `json:"oi"`


### PR DESCRIPTION
to maintain consistency while marshaling / unmarshaling JSON tag has been updated for `low` in `HistoricalData`