### PR TITLE
feat: add unit tests for ModifyOrder and SessionInvalidate

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -141,7 +141,7 @@ var MockResponders = [][]string{
 
 	// PUT endpoints
 	[]string{http.MethodPut, URIModifyMFSIP, "mf_sip_info.json"},
-	[]string{http.MethodPut, URIModifyOrder, "order_response.json"},
+	[]string{http.MethodPut, URIModifyOrder, "order_modify.json"},
 	[]string{http.MethodPut, URIConvertPosition, "positions.json"},
 	[]string{http.MethodPut, fmt.Sprintf(URIModifyGTT, 123), "gtt_modify_order.json"},
 
@@ -158,6 +158,7 @@ var MockResponders = [][]string{
 	[]string{http.MethodDelete, URICancelOrder, "order_response.json"},
 	[]string{http.MethodDelete, URICancelMFSIP, "mf_order_response.json"},
 	[]string{http.MethodDelete, fmt.Sprintf(URIDeleteGTT, 123), "gtt_modify_order.json"},
+	[]string{http.MethodDelete, URIUserSessionInvalidate, "session_logout.json"},
 }
 
 // Test only function prefix with this

--- a/orders_test.go
+++ b/orders_test.go
@@ -123,11 +123,8 @@ func (ts *TestSuite) TestCancelOrder(t *testing.T) {
 	parentOrderID := "test"
 
 	orderResponse, err := ts.KiteConnect.CancelOrder("test", "test", &parentOrderID)
-	if err != nil {
-		t.Errorf("Error while placing order. %v", err)
-	}
-	if orderResponse.OrderID == "" {
-		t.Errorf("No order id returned. Error %v", err)
+	if err != nil || orderResponse.OrderID == "" {
+		t.Errorf("Error while placing cancel order. %v", err)
 	}
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -35,3 +35,11 @@ func (ts *TestSuite) TestGetUserSegmentMargins(t *testing.T) {
 		t.Errorf("Incorrect segment margin values.")
 	}
 }
+
+func (ts *TestSuite) TestInvalidateAccessToken(t *testing.T) {
+	t.Parallel()
+	sessionLogout, err := ts.KiteConnect.InvalidateAccessToken()
+	if err != nil || !sessionLogout == true {
+		t.Errorf("Error while invalidating user session. Error: %v", err)
+	}
+}


### PR DESCRIPTION
Add unit test for InvalidateAccessToken and update test response for ModifyOrder.
@rhnvrm Can you update the go kc mock submodule with the latest version?  `session_logout.json` and `order_modify.json` files are missing in the current mock. 