### PR TITLE
fix: ambigous user_id in json parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .chglog
+.env

--- a/user.go
+++ b/user.go
@@ -14,6 +14,7 @@ type UserSession struct {
 	UserProfile
 	UserSessionTokens
 
+	UserID      string      `json:"user_id"`
 	APIKey      string      `json:"api_key"`
 	PublicToken string      `json:"public_token"`
 	LoginTime   models.Time `json:"login_time"`

--- a/user_test.go
+++ b/user_test.go
@@ -7,7 +7,7 @@ import (
 func (ts *TestSuite) TestGetUserProfile(t *testing.T) {
 	t.Parallel()
 	profile, err := ts.KiteConnect.GetUserProfile()
-	if err != nil || profile.Email == "" {
+	if err != nil || profile.Email == "" || profile.UserID == "" {
 		t.Errorf("Error while reading user profile. Error: %v", err)
 	}
 }


### PR DESCRIPTION
As reported by @vishnus, `user_id` was not being parsed correctly from the responses in UserSession struct as it contained two `user_id` embeds.

This commit fixes the same.