### PR TITLE
fix: negative or zero reconnect delay on higher reconnects

### DIFF
--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -255,7 +255,7 @@ func (t *Ticker) ServeWithContext(ctx context.Context) {
 			// If its a reconnect then wait exponentially based on reconnect attempt
 			if t.reconnectAttempt > 0 {
 				nextDelay := time.Duration(math.Pow(2, float64(t.reconnectAttempt))) * time.Second
-				if nextDelay > t.reconnectMaxDelay {
+				if nextDelay > t.reconnectMaxDelay || nextDelay <= 0 {
 					nextDelay = t.reconnectMaxDelay
 				}
 


### PR DESCRIPTION
The reconnect delay is set to a negative or zero value after 34th attempt. This fix sets the reconnect delay to the max value in that case.

Part of the code before bug fix: https://go.dev/play/p/_gU7UDIEqbh
Part of the code after bug fix: https://go.dev/play/p/GUsYmh9YdKG