### PR TITLE
chore: SetMode usage in README and update ticker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ var (
 	ticker *kiteticker.Ticker
 )
 
+var (
+	instToken = []uint32{408065, 112129}
+)
+
 // Triggered when any error is raised
 func onError(err error) {
 	fmt.Println("Error: ", err)
@@ -96,10 +100,17 @@ func onClose(code int, reason string) {
 // Triggered when connection is established and ready to send and accept data
 func onConnect() {
 	fmt.Println("Connected")
-	err := ticker.Subscribe([]uint32{53718535})
+	err := ticker.Subscribe(instToken)
 	if err != nil {
 		fmt.Println("err: ", err)
 	}
+	// Set subscription mode for the subscribed token
+	// Default mode is Quote
+	err = ticker.SetMode(kiteticker.ModeFull, instToken)
+	if err != nil {
+		fmt.Println("err: ", err)
+	}
+
 }
 
 // Triggered when tick is recevived

--- a/examples/ticker/ticker.go
+++ b/examples/ticker/ticker.go
@@ -14,7 +14,7 @@ import (
 var (
 	apiKey    string = getEnv("KITE_API_KEY", "my_api_key")
 	apiSecret string = getEnv("KITE_API_SECRET", "my_api_secret")
-	instToken int    = getEnvInt("KITE_INSTRUMENT_TOKEN", 408065)
+	instToken uint32 = getEnvUint32("KITE_INSTRUMENT_TOKEN", 408065)
 )
 
 var (
@@ -35,13 +35,13 @@ func onClose(code int, reason string) {
 func onConnect() {
 	fmt.Println("Connected")
 	fmt.Println("Subscribing to", instToken)
-	err := ticker.Subscribe([]uint32{uint32(instToken)})
+	err := ticker.Subscribe([]uint32{instToken})
 	if err != nil {
 		fmt.Println("err: ", err)
 	}
 	// Set subscription mode for given list of tokens
 	// Default mode is Quote
-	err = ticker.SetMode(kiteticker.ModeFull, []uint32{uint32(instToken)})
+	err = ticker.SetMode(kiteticker.ModeFull, []uint32{instToken})
 	if err != nil {
 		fmt.Println("err: ", err)
 	}
@@ -111,14 +111,14 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
-// getEnvInt returns the value of the environment variable provided converted as int.
-func getEnvInt(key string, fallback int) int {
+// getEnvUint32 returns the value of the environment variable provided converted as Uint32.
+func getEnvUint32(key string, fallback int) uint32 {
 	if value, ok := os.LookupEnv(key); ok {
 		i, err := strconv.Atoi(value)
 		if err != nil {
-			return fallback
+			return uint32(fallback)
 		}
-		return i
+		return uint32(i)
 	}
-	return fallback
+	return uint32(fallback)
 }

--- a/examples/ticker/ticker.go
+++ b/examples/ticker/ticker.go
@@ -35,7 +35,7 @@ func onClose(code int, reason string) {
 func onConnect() {
 	fmt.Println("Connected")
 	fmt.Println("Subscribing to", instToken)
-	err := ticker.Subscribe([]uint32{53718535})
+	err := ticker.Subscribe([]uint32{uint32(instToken)})
 	if err != nil {
 		fmt.Println("err: ", err)
 	}


### PR DESCRIPTION
Add missing `SetMode` usage in the README ticker example.