### PR TITLE
feat: Add methods for virtual contract note API

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -113,6 +113,7 @@ const (
 
 	URIOrderMargins  string = "/margins/orders"
 	URIBasketMargins string = "/margins/basket"
+	URIOrderCharges  string = "/charges/orders"
 
 	// MF endpoints
 	URIGetMFOrders      string = "/mf/orders"

--- a/connect_test.go
+++ b/connect_test.go
@@ -157,6 +157,7 @@ var MockResponders = [][]string{
 	{http.MethodPost, URIOrderMargins, "order_margins.json"},
 	{http.MethodPost, URIBasketMargins, "basket_margins.json"},
 	{http.MethodPost, URIInitHoldingsAuth, "holdings_auth.json"},
+	{http.MethodPost, URIOrderCharges, "virtual_contract_note.json"},
 
 	// DELETE endpoints
 	{http.MethodDelete, URICancelOrder, "order_response.json"},

--- a/margins.go
+++ b/margins.go
@@ -174,7 +174,7 @@ func (c *Client) GetBasketMargins(baskparam GetBasketParams) (BasketMargins, err
 	return out, nil
 }
 
-func (c *Client) GetOrdersCharges(chargeParam GetChargesParams) ([]OrderCharges, error) {
+func (c *Client) GetOrderCharges(chargeParam GetChargesParams) ([]OrderCharges, error) {
 	body, err := json.Marshal(chargeParam.OrderParams)
 	if err != nil {
 		return []OrderCharges{}, err

--- a/margins.go
+++ b/margins.go
@@ -19,6 +19,19 @@ type OrderMarginParam struct {
 	TriggerPrice    float64 `json:"trigger_price,omitempty"`
 }
 
+// OrderMarginParam represents an order in the Margin Calculator API
+type OrderChargesParam struct {
+	OrderID         string  `json:"order_id"`
+	Exchange        string  `json:"exchange"`
+	Tradingsymbol   string  `json:"tradingsymbol"`
+	TransactionType string  `json:"transaction_type"`
+	Variety         string  `json:"variety"`
+	Product         string  `json:"product"`
+	OrderType       string  `json:"order_type"`
+	Quantity        float64 `json:"quantity"`
+	AveragePrice    float64 `json:"average_price"`
+}
+
 // PNL represents the PNL
 type PNL struct {
 	Realised   float64 `json:"realised"`
@@ -42,6 +55,18 @@ type OrderMargins struct {
 	Leverage      float64 `json:"leverage"`
 	Charges       Charges `json:"charges"`
 	Total         float64 `json:"total"`
+}
+
+type OrderCharges struct {
+	Exchange        string  `json:"exchange"`
+	Tradingsymbol   string  `json:"tradingsymbol"`
+	TransactionType string  `json:"transaction_type"`
+	Variety         string  `json:"variety"`
+	Product         string  `json:"product"`
+	OrderType       string  `json:"order_type"`
+	Quantity        float64 `json:"quantity"`
+	Price           float64 `json:"price"`
+	Charges         Charges `json:"charges"`
 }
 
 // Charges represents breakdown of various charges that are applied to an order
@@ -80,6 +105,10 @@ type GetBasketParams struct {
 	OrderParams       []OrderMarginParam
 	Compact           bool
 	ConsiderPositions bool
+}
+
+type GetChargesParams struct {
+	OrderParams []OrderChargesParam
 }
 
 func (c *Client) GetOrderMargins(marparam GetMarginParams) ([]OrderMargins, error) {
@@ -139,6 +168,29 @@ func (c *Client) GetBasketMargins(baskparam GetBasketParams) (BasketMargins, err
 	var out BasketMargins
 	if err := readEnvelope(resp, &out); err != nil {
 		return BasketMargins{}, err
+	}
+
+	return out, nil
+}
+
+func (c *Client) GetOrdersCharges(chargeParam GetChargesParams) ([]OrderCharges, error) {
+	body, err := json.Marshal(chargeParam.OrderParams)
+	if err != nil {
+		return []OrderCharges{}, err
+	}
+
+	var headers http.Header = map[string][]string{}
+	headers.Add("Content-Type", "application/json")
+
+	uri := URIOrderCharges
+	resp, err := c.doRaw(http.MethodPost, uri, body, headers)
+	if err != nil {
+		return []OrderCharges{}, err
+	}
+
+	var out []OrderCharges
+	if err := readEnvelope(resp, &out); err != nil {
+		return []OrderCharges{}, err
 	}
 
 	return out, nil

--- a/margins.go
+++ b/margins.go
@@ -19,7 +19,7 @@ type OrderMarginParam struct {
 	TriggerPrice    float64 `json:"trigger_price,omitempty"`
 }
 
-// OrderMarginParam represents an order in the Margin Calculator API
+// OrderChargesParam represents an order in the Charges Calculator API
 type OrderChargesParam struct {
 	OrderID         string  `json:"order_id"`
 	Exchange        string  `json:"exchange"`
@@ -57,6 +57,7 @@ type OrderMargins struct {
 	Total         float64 `json:"total"`
 }
 
+// OrderCharges represent an item's response from the Charges calculator API
 type OrderCharges struct {
 	Exchange        string  `json:"exchange"`
 	Tradingsymbol   string  `json:"tradingsymbol"`

--- a/margins_test.go
+++ b/margins_test.go
@@ -109,26 +109,50 @@ func (ts *TestSuite) TestGetOrderCharges(t *testing.T) {
 	t.Parallel()
 
 	params :=
-		OrderChargesParam{
-			Exchange:        "NSE",
-			Tradingsymbol:   "INFY",
-			TransactionType: "BUY",
-			Variety:         "regular",
-			Product:         "CNC",
-			OrderType:       "MARKET",
-			Quantity:        1,
-			AveragePrice:    10,
-			OrderID:         "11111",
+		[]OrderChargesParam{
+			{
+				Exchange:        "SBIN",
+				Tradingsymbol:   "INFY",
+				TransactionType: "BUY",
+				Variety:         "regular",
+				Product:         "CNC",
+				OrderType:       "MARKET",
+				Quantity:        1,
+				AveragePrice:    560,
+				OrderID:         "11111",
+			},
+			{
+				Exchange:        "MCX",
+				Tradingsymbol:   "GOLDPETAL23JULFUT",
+				TransactionType: "SELL",
+				Variety:         "regular",
+				Product:         "NRML",
+				OrderType:       "LIMIT",
+				Quantity:        1,
+				AveragePrice:    5862,
+				OrderID:         "11111",
+			},
+			{
+				Exchange:        "NFO",
+				Tradingsymbol:   "NIFTY2371317900PE",
+				TransactionType: "BUY",
+				Variety:         "regular",
+				Product:         "NRML",
+				OrderType:       "LIMIT",
+				Quantity:        100,
+				AveragePrice:    1.5,
+				OrderID:         "11111",
+			},
 		}
 
 	orderResponseCharges, err := ts.KiteConnect.GetOrderCharges(GetChargesParams{
-		OrderParams: []OrderChargesParam{params},
+		OrderParams: params,
 	})
 	if err != nil {
-		t.Errorf("Error while getting compact basket order margins: %v", err)
+		t.Errorf("Error while getting order charges: %v", err)
 	}
 
 	if len(orderResponseCharges) != 1 {
-		t.Errorf("Incorrect response, expected len(orderResponseBasket.Orders) to be 2, got: %v", len(orderResponseCharges))
+		t.Errorf("Incorrect response, expected len(orderResponseCharges) to be 3, got: %v", len(orderResponseCharges))
 	}
 }

--- a/margins_test.go
+++ b/margins_test.go
@@ -152,7 +152,7 @@ func (ts *TestSuite) TestGetOrderCharges(t *testing.T) {
 		t.Errorf("Error while getting order charges: %v", err)
 	}
 
-	if len(orderResponseCharges) != 1 {
+	if len(orderResponseCharges) != 3 {
 		t.Errorf("Incorrect response, expected len(orderResponseCharges) to be 3, got: %v", len(orderResponseCharges))
 	}
 }

--- a/margins_test.go
+++ b/margins_test.go
@@ -104,3 +104,31 @@ func (ts *TestSuite) TestGetBasketMargins(t *testing.T) {
 		t.Errorf("Incorrect response, expected len(orderResponseBasket.Orders) to be 2, got: %v", len(orderResponseBasket.Orders))
 	}
 }
+
+func (ts *TestSuite) TestGetOrderCharges(t *testing.T) {
+	t.Parallel()
+
+	params :=
+		OrderChargesParam{
+			Exchange:        "NSE",
+			Tradingsymbol:   "INFY",
+			TransactionType: "BUY",
+			Variety:         "regular",
+			Product:         "CNC",
+			OrderType:       "MARKET",
+			Quantity:        1,
+			AveragePrice:    10,
+			OrderID:         "11111",
+		}
+
+	orderResponseCharges, err := ts.KiteConnect.GetOrdersCharges(GetChargesParams{
+		OrderParams: []OrderChargesParam{params},
+	})
+	if err != nil {
+		t.Errorf("Error while getting compact basket order margins: %v", err)
+	}
+
+	if len(orderResponseCharges) != 1 {
+		t.Errorf("Incorrect response, expected len(orderResponseBasket.Orders) to be 2, got: %v", len(orderResponseCharges))
+	}
+}

--- a/margins_test.go
+++ b/margins_test.go
@@ -130,7 +130,7 @@ func (ts *TestSuite) TestGetOrderCharges(t *testing.T) {
 				OrderType:       "LIMIT",
 				Quantity:        1,
 				AveragePrice:    5862,
-				OrderID:         "11111",
+				OrderID:         "22222",
 			},
 			{
 				Exchange:        "NFO",
@@ -141,7 +141,7 @@ func (ts *TestSuite) TestGetOrderCharges(t *testing.T) {
 				OrderType:       "LIMIT",
 				Quantity:        100,
 				AveragePrice:    1.5,
-				OrderID:         "11111",
+				OrderID:         "33333",
 			},
 		}
 

--- a/margins_test.go
+++ b/margins_test.go
@@ -121,7 +121,7 @@ func (ts *TestSuite) TestGetOrderCharges(t *testing.T) {
 			OrderID:         "11111",
 		}
 
-	orderResponseCharges, err := ts.KiteConnect.GetOrdersCharges(GetChargesParams{
+	orderResponseCharges, err := ts.KiteConnect.GetOrderCharges(GetChargesParams{
 		OrderParams: []OrderChargesParam{params},
 	})
 	if err != nil {


### PR DESCRIPTION
This PR adds a method `GetOrderCharges`  that underlying calls the virtual contract note charges API. Please also provide suggestions (if needed) on the naming of exported variables.