### PR TITLE
fix: synchronize access to lastPingTime in ticker struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .chglog
 .env
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": ["master"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "githubPullRequests.ignoredPullRequestBranches": ["master"]
-}

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -28,7 +29,7 @@ type Ticker struct {
 
 	url                 url.URL
 	callbacks           callbacks
-	lastPingTime        time.Time
+	lastPingTime        atomicTime
 	autoReconnect       bool
 	reconnectMaxRetries int
 	reconnectMaxDelay   time.Duration
@@ -39,8 +40,22 @@ type Ticker struct {
 	subscribedTokens map[uint32]Mode
 
 	cancel context.CancelFunc
+}
 
-	lastPingTimeMutex sync.Mutex
+// atomicTime is wrapper over time.Time to safely access
+// an updating timestamp concurrently.
+type atomicTime struct {
+	v atomic.Value
+}
+	
+// Get returns the current timestamp.
+func (b *atomicTime) Get() time.Time {
+	return b.v.Load().(time.Time)
+}
+	 
+// Set sets the current timestamp.
+func (b *atomicTime) Set(value time.Time) {
+	b.v.Store(value)
 }
 
 // callbacks represents callbacks available in ticker.
@@ -313,7 +328,7 @@ func (t *Ticker) ServeWithContext(ctx context.Context) {
 			t.reconnectAttempt = 0
 
 			// Set current time as last ping time
-			t.lastPingTime = time.Now()
+			t.lastPingTime.Set(time.Now())
 
 			// Set on close handler
 			t.Conn.SetCloseHandler(t.handleClose)
@@ -341,11 +356,6 @@ func (t *Ticker) handleClose(code int, reason string) error {
 	return nil
 }
 
-func (t *Ticker) getLastPingTime() time.Time {
-	t.lastPingTimeMutex.Lock()
-	defer t.lastPingTimeMutex.Unlock()
-	return t.lastPingTime
-}
 
 // Trigger callback methods
 func (t *Ticker) triggerError(err error) {
@@ -378,11 +388,6 @@ func (t *Ticker) triggerNoReconnect(attempt int) {
 	}
 }
 
-func (t *Ticker) setLastPingTime(time time.Time) {
-	t.lastPingTimeMutex.Lock()
-	defer t.lastPingTimeMutex.Unlock()
-	t.lastPingTime = time
-}
 
 func (t *Ticker) triggerMessage(messageType int, message []byte) {
 	if t.callbacks.onMessage != nil {
@@ -415,7 +420,7 @@ func (t *Ticker) checkConnection(ctx context.Context, wg *sync.WaitGroup) {
 
 			// If last ping time is greater then timeout interval then close the
 			// existing connection and reconnect
-			if time.Since(t.getLastPingTime()) > dataTimeoutInterval {
+			if time.Since(t.lastPingTime.Get()) > dataTimeoutInterval {
 				// Close the current connection without waiting for close frame
 				if t.Conn != nil {
 					t.Conn.Close()
@@ -445,7 +450,7 @@ func (t *Ticker) readMessage(ctx context.Context, wg *sync.WaitGroup) {
 			}
 
 			// Update last ping time to check for connection
-			t.setLastPingTime(time.Now())
+			t.lastPingTime.Set(time.Now())
 
 			// Trigger message.
 			t.triggerMessage(mType, msg)

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -445,10 +445,10 @@ func (t *Ticker) readMessage(ctx context.Context, wg *sync.WaitGroup) {
 			}
 
 			// Update last ping time to check for connection
-			t.lastPingTime = time.Now()
+			t.SetLastPingTime(time.Now())
 
 			// Trigger message.
-			t.SetLastPingTime(time.Now())
+			t.triggerMessage(mType, msg)
 
 			// If binary message then parse and send tick.
 			if mType == websocket.BinaryMessage {

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -341,7 +341,7 @@ func (t *Ticker) handleClose(code int, reason string) error {
 	return nil
 }
 
-func (t *Ticker) GetLastPingTime() time.Time {
+func (t *Ticker) getLastPingTime() time.Time {
 	t.lastPingTimeMutex.Lock()
 	defer t.lastPingTimeMutex.Unlock()
 	return t.lastPingTime
@@ -378,7 +378,7 @@ func (t *Ticker) triggerNoReconnect(attempt int) {
 	}
 }
 
-func (t *Ticker) SetLastPingTime(time time.Time) {
+func (t *Ticker) setLastPingTime(time time.Time) {
 	t.lastPingTimeMutex.Lock()
 	defer t.lastPingTimeMutex.Unlock()
 	t.lastPingTime = time
@@ -415,7 +415,7 @@ func (t *Ticker) checkConnection(ctx context.Context, wg *sync.WaitGroup) {
 
 			// If last ping time is greater then timeout interval then close the
 			// existing connection and reconnect
-			if time.Since(t.GetLastPingTime()) > dataTimeoutInterval {
+			if time.Since(t.getLastPingTime()) > dataTimeoutInterval {
 				// Close the current connection without waiting for close frame
 				if t.Conn != nil {
 					t.Conn.Close()
@@ -445,7 +445,7 @@ func (t *Ticker) readMessage(ctx context.Context, wg *sync.WaitGroup) {
 			}
 
 			// Update last ping time to check for connection
-			t.SetLastPingTime(time.Now())
+			t.setLastPingTime(time.Now())
 
 			// Trigger message.
 			t.triggerMessage(mType, msg)


### PR DESCRIPTION
Modified the Ticker struct to include a mutex for synchronizing access to the lastPingTime property. This change ensures that the lastPingTime property is accessed safely by multiple goroutines concurrently.

- Added lastPingTimeMutex to Ticker struct
- Introduced SetLastPingTime and GetLastPingTime methods to safely set and get lastPingTime
- Updated readMessage function to use SetLastPingTime to update lastPingTime
- Updated checkConnection function to use GetLastPingTime to access lastPingTime

Resolves: Data race issue in Ticker methods

Closes #98 