### PR TITLE
Allow setting product type for GTT orders

### DIFF
--- a/gtt.go
+++ b/gtt.go
@@ -109,12 +109,17 @@ type GTTParams struct {
 	Exchange        string
 	LastPrice       float64
 	TransactionType string
+	Product         string
 	Trigger         Trigger
 }
 
 func newGTT(o GTTParams) GTT {
 	var orders Orders
 
+	product := o.Product
+	if product == "" {
+		product = ProductCNC
+	}
 	for i := range o.Trigger.TriggerValues() {
 		orders = append(orders, Order{
 			Exchange:        o.Exchange,
@@ -123,7 +128,7 @@ func newGTT(o GTTParams) GTT {
 			Quantity:        o.Trigger.Quantities()[i],
 			Price:           o.Trigger.LimitPrices()[i],
 			OrderType:       OrderTypeLimit,
-			Product:         ProductCNC,
+			Product:         product,
 		})
 	}
 	return GTT{


### PR DESCRIPTION
This commit modifies the `newGTT` function to accept a `Product` parameter in the `GTTParams` struct. If this parameter is provided, it will set the product type for GTT orders accordingly. If the parameter is empty, it defaults to `ProductCNC`.

This enhancement provides more flexibility for users to specify the product type when creating GTT orders, addressing issues where CNC product type may not be suitable for certain trading scenarios.

Closes #103 