### PR TITLE
fix: use correct URI for GetLTP and GetOHLC

### DIFF
--- a/market.go
+++ b/market.go
@@ -154,7 +154,7 @@ func (c *Client) GetLTP(instruments ...string) (QuoteLTP, error) {
 		return quotes, NewError(InputError, fmt.Sprintf("Error decoding order params: %v", err), nil)
 	}
 
-	err = c.doEnvelope(http.MethodGet, URIGetQuote, params, nil, &quotes)
+	err = c.doEnvelope(http.MethodGet, URIGetLTP, params, nil, &quotes)
 	return quotes, err
 }
 
@@ -175,7 +175,7 @@ func (c *Client) GetOHLC(instruments ...string) (QuoteOHLC, error) {
 		return quotes, NewError(InputError, fmt.Sprintf("Error decoding order params: %v", err), nil)
 	}
 
-	err = c.doEnvelope(http.MethodGet, URIGetQuote, params, nil, &quotes)
+	err = c.doEnvelope(http.MethodGet, URIGetOHLC, params, nil, &quotes)
 	return quotes, err
 }
 


### PR DESCRIPTION
GetLTP was calling `/quote` instead of `/quote/ltp` and GetOHLC was calling `/quote` instead of `/quote/ohlc`. This meant users got the full quote payload instead of the lighter endpoints, and were limited to 500 instruments instead of the 1000 that `/quote/ltp` and `/quote/ohlc` support.

Per the [Kite Connect v3 docs](https://kite.trade/docs/connect/v3/market-quotes/):
- `/quote` - full market quotes, up to 500 instruments
- `/quote/ltp` - LTP only, up to 1000 instruments
- `/quote/ohlc` - OHLC + LTP, up to 1000 instruments

Fixes #112