### PR TITLE
fix(alerts): preserve uuids on delete

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -142,25 +142,25 @@ type AlertHistory struct {
 
 // AlertHistoryMeta represents meta info for alert history.
 type AlertHistoryMeta struct {
-	InstrumentToken   int     `json:"instrument_token"`
-	TradingSymbol     string  `json:"tradingsymbol"`
-	Timestamp         string  `json:"timestamp"`
-	LastPrice         float64 `json:"last_price"`
+	InstrumentToken   int         `json:"instrument_token"`
+	TradingSymbol     string      `json:"tradingsymbol"`
+	Timestamp         string      `json:"timestamp"`
+	LastPrice         float64     `json:"last_price"`
 	OHLC              models.OHLC `json:"ohlc"`
-	NetChange         float64 `json:"net_change"`
-	Exchange          string  `json:"exchange"`
-	LastTradeTime     string  `json:"last_trade_time"`
-	LastQuantity      int     `json:"last_quantity"`
-	BuyQuantity       int     `json:"buy_quantity"`
-	SellQuantity      int     `json:"sell_quantity"`
-	Volume            int     `json:"volume"`
-	VolumeTick        int     `json:"volume_tick"`
-	AveragePrice      float64 `json:"average_price"`
-	OI                int     `json:"oi"`
-	OIDayHigh         int     `json:"oi_day_high"`
-	OIDayLow          int     `json:"oi_day_low"`
-	LowerCircuitLimit float64 `json:"lower_circuit_limit"`
-	UpperCircuitLimit float64 `json:"upper_circuit_limit"`
+	NetChange         float64     `json:"net_change"`
+	Exchange          string      `json:"exchange"`
+	LastTradeTime     string      `json:"last_trade_time"`
+	LastQuantity      int         `json:"last_quantity"`
+	BuyQuantity       int         `json:"buy_quantity"`
+	SellQuantity      int         `json:"sell_quantity"`
+	Volume            int         `json:"volume"`
+	VolumeTick        int         `json:"volume_tick"`
+	AveragePrice      float64     `json:"average_price"`
+	OI                int         `json:"oi"`
+	OIDayHigh         int         `json:"oi_day_high"`
+	OIDayLow          int         `json:"oi_day_low"`
+	LowerCircuitLimit float64     `json:"lower_circuit_limit"`
+	UpperCircuitLimit float64     `json:"upper_circuit_limit"`
 }
 
 // CreateAlert creates a new alert.
@@ -267,8 +267,7 @@ func (c *Client) DeleteAlerts(uuids ...string) error {
 		Status string      `json:"status"`
 		Data   interface{} `json:"data"`
 	}
-	deleteURL := URIAlerts + "?" + params.Encode()
-	err := c.doEnvelope(http.MethodDelete, deleteURL, nil, nil, &resp)
+	err := c.doEnvelope(http.MethodDelete, URIAlerts, params, nil, &resp)
 	return err
 }
 

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -1,6 +1,9 @@
 package kiteconnect
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -83,6 +86,31 @@ func (ts *TestSuite) TestDeleteAlerts(t *testing.T) {
 	err := ts.KiteConnect.DeleteAlerts(testUUID)
 	if err != nil {
 		t.Errorf("Error while deleting alert: %v", err)
+	}
+}
+
+func TestDeleteAlertsPreservesUUIDQuery(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE request, got %s", r.Method)
+		}
+		if got := r.URL.Query()["uuid"]; len(got) != 2 || got[0] != "uuid-1" || got[1] != "uuid-2" {
+			t.Fatalf("expected uuid query values to be preserved, got %v", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"success","data":null}`)
+	}))
+	defer server.Close()
+
+	kc := New("test_api_key")
+	kc.SetBaseURI(server.URL)
+	kc.SetAccessToken("test_access_token")
+
+	err := kc.DeleteAlerts("uuid-1", "uuid-2")
+	if err != nil {
+		t.Fatalf("expected delete alerts to succeed, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix `DeleteAlerts()` to pass UUIDs via `params` instead of embedding them in the URL
- preserve UUID query parameters for DELETE requests through the shared HTTP helper
- add a regression test covering multiple UUID query values

## Root cause
`DeleteAlerts()` was building `/alerts?uuid=...` manually and then calling `doEnvelope()` with `params=nil`. The shared HTTP helper rewrites `RawQuery` for DELETE requests from `params`, which dropped the UUIDs entirely.

## Testing
- `go test ./...`